### PR TITLE
Add support to cifs version option

### DIFF
--- a/plex/config.json
+++ b/plex/config.json
@@ -47,7 +47,8 @@
         "webtools": false,
         "networkdisks": ["<//SERVER/SHARE>"],
         "cifsusername": "<username>",
-        "cifspassword": "<password>"
+        "cifspassword": "<password>",
+        "cifsversion": "3.0"
     },
     "schema": {
         "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
@@ -55,6 +56,7 @@
         "webtools": "bool",
         "networkdisks": ["str"],
         "cifsusername": "str",
-        "cifspassword": "str"
+        "cifspassword": "str",
+        "cifsversion": "str"
     }
 }

--- a/plex/config.json
+++ b/plex/config.json
@@ -57,6 +57,6 @@
         "networkdisks": ["str"],
         "cifsusername": "str",
         "cifspassword": "str",
-        "cifsversion": "str"
+        "cifsversion": "list(3.0|2.1|2.0|1.0)?"
     }
 }

--- a/plex/rootfs/etc/services.d/plex/run
+++ b/plex/rootfs/etc/services.d/plex/run
@@ -17,12 +17,13 @@ if bashio::config.has_value 'networkdisks'; then
     MOREDISKS=$(bashio::config 'networkdisks')
     CIFS_USERNAME=$(bashio::config 'cifsusername')
     CIFS_PASSWORD=$(bashio::config 'cifspassword')
+    CIFS_VERSION=$(bashio::config 'cifsversion')
     bashio::log.info "Network Disks mounting.. ${MOREDISKS}" && \
     for disk in $MOREDISKS 
     do
         bashio::log.info "Mount ${disk}"
         mkdir -p /$disk && \
-            mount -t cifs -o username=$CIFS_USERNAME,password=$CIFS_PASSWORD $disk /$disk && \
+            mount -t cifs -o username=$CIFS_USERNAME,password=$CIFS_PASSWORD,vers=$CIFS_VERSION $disk /$disk && \
             bashio::log.info "Success!"   
     done || \
     bashio::log.warning "Protection mode is ON. Unable to mount external drivers!"

--- a/plex/rootfs/etc/services.d/plex/run
+++ b/plex/rootfs/etc/services.d/plex/run
@@ -17,7 +17,11 @@ if bashio::config.has_value 'networkdisks'; then
     MOREDISKS=$(bashio::config 'networkdisks')
     CIFS_USERNAME=$(bashio::config 'cifsusername')
     CIFS_PASSWORD=$(bashio::config 'cifspassword')
-    CIFS_VERSION=$(bashio::config 'cifsversion')
+    if bashio::config.has_value 'cifsversion'; then
+        CIFS_VERSION=$(bashio::config 'cifsversion')
+    else
+        CIFS_VERSION="3.0"
+    fi
     bashio::log.info "Network Disks mounting.. ${MOREDISKS}" && \
     for disk in $MOREDISKS 
     do


### PR DESCRIPTION
# Proposed Changes

> Allow CIFS version to be configurable through options

## Related Issues

> [#1 Add support to CIFS version argument](https://github.com/dianlight/addon-plex/issues/1)

Because the change was very simple, I opened this Pull Request directly after writing the Issue. Feel free to change the code or even close this PR if you think this is not welcome.