### PR TITLE
Remove CIFS version arg when it is not given

### DIFF
--- a/plex/config.json
+++ b/plex/config.json
@@ -48,7 +48,7 @@
         "networkdisks": ["<//SERVER/SHARE>"],
         "cifsusername": "<username>",
         "cifspassword": "<password>",
-        "cifsversion": "3.0"
+        "cifsversion": ""
     },
     "schema": {
         "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",

--- a/plex/rootfs/etc/services.d/plex/run
+++ b/plex/rootfs/etc/services.d/plex/run
@@ -18,16 +18,14 @@ if bashio::config.has_value 'networkdisks'; then
     CIFS_USERNAME=$(bashio::config 'cifsusername')
     CIFS_PASSWORD=$(bashio::config 'cifspassword')
     if bashio::config.has_value 'cifsversion'; then
-        CIFS_VERSION=$(bashio::config 'cifsversion')
-    else
-        CIFS_VERSION="3.0"
+        CIFS_VERSION_ARG=",vers=$(bashio::config 'cifsversion')"
     fi
     bashio::log.info "Network Disks mounting.. ${MOREDISKS}" && \
     for disk in $MOREDISKS 
     do
         bashio::log.info "Mount ${disk}"
         mkdir -p /$disk && \
-            mount -t cifs -o username=$CIFS_USERNAME,password=$CIFS_PASSWORD,vers=$CIFS_VERSION $disk /$disk && \
+            mount -t cifs -o username=$CIFS_USERNAME,password=$CIFS_PASSWORD$CIFS_VERSION_ARG $disk /$disk && \
             bashio::log.info "Success!"   
     done || \
     bashio::log.warning "Protection mode is ON. Unable to mount external drivers!"


### PR DESCRIPTION
# Proposed Changes

> Mount without `vers` argument when `cifsversion` parameter is not given.

## Related Issues

> [Version handshake don’t work on cifs](https://github.com/dianlight/addon-plex/pull/2#issuecomment-767368652)