### PR TITLE
Upgrades Plex Media Server to 1.26.2.5797

### DIFF
--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base system
 ARG BUILD_ARCH=amd64
-ARG RELEASE=1.25.5.5492-12f6b8c83
+ARG RELEASE=1.26.2.5797-5bd057d2b
 RUN \
     apt-get update \
     \


### PR DESCRIPTION
# Proposed Changes

Plex Server is outdated, Here's a much needed version bump.
Plex won't annoyingly ask to change the library agent in TV Series library anymore.

## Related Issues
This is also asked in #14 
